### PR TITLE
Fix: root path of webui

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -18,6 +18,6 @@ chown $PUID:$PGID /conf/aria2.session
 touch /logs.txt
 chown $PUID:$PGID /logs.txt
 
-darkhttpd /aria2-webui --port 80 &
+darkhttpd /aria2-webui/docs --port 80 &
 
 exec s6-setuidgid $PUID:$PGID aria2c --conf-path=/conf/aria2.conf --log=/logs.txt


### PR DESCRIPTION
root path of webui is now located at /docs