### PR TITLE
Disable IPv6 binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN	apk add --no-cache git && \
 	git clone --depth 1 https://github.com/ziahamza/webui-aria2 /aria2-webui && \
 	apk del git
 
+RUN apk add --no-cache wget
+
 ADD files/start.sh /conf-copy/start.sh
 ADD files/aria2.conf /conf-copy/aria2.conf
 

--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -18,3 +18,4 @@ enable-rpc=true
 rpc-listen-all=true
 rpc-allow-origin-all=true
 rpc-listen-port=6800
+disable-ipv6=true

--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -2,7 +2,7 @@ dir=/data
 input-file=/conf/aria2.session
 save-session=/conf/aria2.session
 
-file-allocation=falloc
+file-allocation=prealloc
 log-level=warn
 enable-http-pipelining=true
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -20,4 +20,4 @@ chown $PUID:$PGID /logs.txt
 
 darkhttpd /aria2-webui/docs --port 80 &
 
-exec s6-setuidgid $PUID:$PGID aria2c --conf-path=/conf/aria2.conf --log=/logs.txt
+exec s6-setuidgid $PUID:$PGID aria2c --disable-ipv6=true --conf-path=/conf/aria2.conf --log=/logs.txt

--- a/files/start.sh
+++ b/files/start.sh
@@ -20,4 +20,6 @@ chown $PUID:$PGID /logs.txt
 
 darkhttpd /aria2-webui/docs --port 80 &
 
+echo "Your public IP is $(wget -qO- https://ipecho.net/plain ; echo)"
+
 exec s6-setuidgid $PUID:$PGID aria2c --disable-ipv6=true --conf-path=/conf/aria2.conf --log=/logs.txt


### PR DESCRIPTION
This option needs to be set as the Docker instance fails to start without it with bind errors.

Here is a sample error:

```
05/01 11:40:57 [NOTICE] IPv4 RPC: listening on TCP port 6800

05/01 11:40:57 [ERROR] IPv6 RPC: failed to bind TCP port 6800
Exception: [SocketCore.cc:312] errorCode=1 Failed to bind a socket, cause: Name does not resolve
```

After setting this option, the error goes away, as now Aria2 will not try to bind to IPv6.